### PR TITLE
Disallow NULL/blank values for users columns

### DIFF
--- a/lib/generators/monban/scaffold/scaffold_generator.rb
+++ b/lib/generators/monban/scaffold/scaffold_generator.rb
@@ -30,7 +30,8 @@ module Monban
       end
 
       def add_model
-        generate 'model', 'user email password_digest'
+        template 'app/models/user.rb', 'app/models/user.rb'
+        migration_template "db/migrate/create_users.rb", "db/migrate/create_users.rb"
       end
 
       def display_readme

--- a/lib/generators/monban/templates/app/models/user.rb
+++ b/lib/generators/monban/templates/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+  validates :email, presence: true, uniqueness: true
+  validates :password_digest, presence: true
+end

--- a/lib/generators/monban/templates/db/migrate/create_users.rb
+++ b/lib/generators/monban/templates/db/migrate/create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email, unique: true
+  end
+end


### PR DESCRIPTION
The `email` and `password_digest` columns, along with timestamp columns, are now
marked as `NOT NULL`. The User model also has presence validations for `email`
and `password_digest`.

Emails are also now forced to be unique.
