### PR TITLE
Remove excess whitespace from controller templates

### DIFF
--- a/lib/generators/monban/templates/app/controllers/sessions_controller.rb
+++ b/lib/generators/monban/templates/app/controllers/sessions_controller.rb
@@ -25,4 +25,3 @@ class SessionsController < ApplicationController
     params.require(:session).permit(:email, :password)
   end
 end
-

--- a/lib/generators/monban/templates/app/controllers/users_controller.rb
+++ b/lib/generators/monban/templates/app/controllers/users_controller.rb
@@ -22,4 +22,3 @@ class UsersController < ApplicationController
     params.require(:user).permit(:email, :password)
   end
 end
-


### PR DESCRIPTION
Removes excess whitespace added to the sessions and users controllers by the generators
