### PR TITLE
Compatibility with older version of ActiveRecord

### DIFF
--- a/lib/generators/monban/google_oauth2/google_oauth2_generator.rb
+++ b/lib/generators/monban/google_oauth2/google_oauth2_generator.rb
@@ -1,9 +1,12 @@
 require 'rails/generators/active_record'
+require 'generators/monban/migration/version'
 
 module Monban
   module Generators
     class GoogleOauth2Generator < Rails::Generators::Base
       include Rails::Generators::Migration
+      include Monban::Generators::Migration
+
       source_root File.expand_path("../../templates", __FILE__)
 
       def add_gems
@@ -32,7 +35,7 @@ module Monban
 
       def add_model
         template 'app/models/external_credential.rb', 'app/models/external_credential.rb'
-        migration_template "db/migrate/create_external_credentials.rb", "db/migrate/create_external_credentials.rb"
+        migration_template "db/migrate/create_external_credentials.rb", "db/migrate/create_external_credentials.rb", migration_version: migration_version
       end
 
       def display_readme

--- a/lib/generators/monban/migration/version.rb
+++ b/lib/generators/monban/migration/version.rb
@@ -1,0 +1,11 @@
+module Monban
+  module Generators
+    module Migration
+      def migration_version
+        if Rails.version.start_with? '5'
+          "[#{ActiveRecord::Migration.current_version}]"
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/monban/password_reset/password_reset_generator.rb
+++ b/lib/generators/monban/password_reset/password_reset_generator.rb
@@ -1,9 +1,12 @@
 require 'rails/generators/active_record'
+require 'generators/monban/migration/version'
 
 module Monban
   module Generators
     class PasswordResetGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
+      include Monban::Generators::Migration
+
       source_root File.expand_path("../../templates", __FILE__)
 
       def add_config_options
@@ -39,7 +42,7 @@ module Monban
 
       def add_model
         template 'app/models/password_reset.rb', 'app/models/password_reset.rb'
-        migration_template "db/migrate/create_password_resets.rb", "db/migrate/create_password_resets.rb"
+        migration_template "db/migrate/create_password_resets.rb", "db/migrate/create_password_resets.rb", migration_version: migration_version
       end
 
       def display_readme

--- a/lib/generators/monban/scaffold/scaffold_generator.rb
+++ b/lib/generators/monban/scaffold/scaffold_generator.rb
@@ -1,9 +1,12 @@
 require 'rails/generators/active_record'
+require 'generators/monban/migration/version'
 
 module Monban
   module Generators
     class ScaffoldGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
+      include Monban::Generators::Migration
+
       source_root File.expand_path("../../templates", __FILE__)
 
       def add_routes
@@ -31,7 +34,7 @@ module Monban
 
       def add_model
         template 'app/models/user.rb', 'app/models/user.rb'
-        migration_template "db/migrate/create_users.rb", "db/migrate/create_users.rb"
+        migration_template "db/migrate/create_users.rb", "db/migrate/create_users.rb", migration_version: migration_version
       end
 
       def add_translations

--- a/lib/generators/monban/templates/db/migrate/create_external_credentials.rb
+++ b/lib/generators/monban/templates/db/migrate/create_external_credentials.rb
@@ -1,4 +1,4 @@
-class CreateExternalCredentials < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class CreateExternalCredentials < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :external_credentials do |t|
       t.string :uid

--- a/lib/generators/monban/templates/db/migrate/create_password_resets.rb
+++ b/lib/generators/monban/templates/db/migrate/create_password_resets.rb
@@ -1,4 +1,4 @@
-class CreatePasswordResets < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class CreatePasswordResets < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :password_resets do |t|
       t.belongs_to :user, index: true

--- a/lib/generators/monban/templates/db/migrate/create_users.rb
+++ b/lib/generators/monban/templates/db/migrate/create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class CreateUsers < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :users do |t|
       t.string :email, null: false


### PR DESCRIPTION
```ActiveRecord::Migration.current_version``` is not supported by 4th version of ActiveRecord.